### PR TITLE
fix(crawl-news): bump Node to 24 and pin pnpm via packageManager

### DIFF
--- a/.github/workflows/crawl-news.yml
+++ b/.github/workflows/crawl-news.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack
         run: corepack enable

--- a/command/crawl-news/package.json
+++ b/command/crawl-news/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@11.0.9",
   "pnpm": {
     "overrides": {
       "minimatch": ">=10.2.3",

--- a/command/crawl-news/package.json
+++ b/command/crawl-news/package.json
@@ -25,6 +25,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "overrides": {
       "minimatch": ">=10.2.3",


### PR DESCRIPTION
## Summary
- Crawl News ワークフローが `pnpm install --frozen-lockfile` で `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` を出して失敗していた
- 原因は `command/crawl-news/package.json` に `packageManager` フィールドが無く、corepack が最新の pnpm 11.0.9 を取得していたこと。pnpm 11.x は Node.js >=22.13 を要求するが、ワークフローは Node 20 を使用していた
- 対応:
  - ワークフローの Node.js を `20` → `24` にアップデート
  - `command/crawl-news/package.json` に `"packageManager": "pnpm@11.0.9"` を追加し、使用する pnpm を最新版にピン留め

## Test plan
- [ ] `Crawl News` ワークフローを `workflow_dispatch` で手動実行し、`Install dependencies` が成功すること
- [ ] `Run crawl-news` ステップが正常に完走すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)